### PR TITLE
Added new ingress for channel stub apis

### DIFF
--- a/helm/ph-ee-engine/templates/connector-channel.yaml
+++ b/helm/ph-ee-engine/templates/connector-channel.yaml
@@ -97,7 +97,33 @@ spec:
         - "{{ .Values.wildcardhostname }}"
       secretName: "{{ .Values.tls }}"
 {{- end }}
+---
+{{- if .Values.channel.ingress.enabled }}
+apiVersion: {{ .Values.ingress.apiversion }}
+kind: Ingress
+metadata:
+  name: ph-ee-connector-channel-gsma
+  annotations:
+{{- if .Values.channel.ingress.annotations }}
+{{ toYaml .Values.channel.ingress.annotations | indent 4 }}
+{{- end }}
+spec:
+  rules:
+    - host: "{{ .Values.channel.stub_hostname }}"
+      http:
+        paths:
+        - path: "{{ .Values.channel.ingress.path }}"
+          pathType: Prefix
+          backend:
+{{- if .Values.channel.ingress.backend }}
+{{ toYaml .Values.channel.ingress.stub_backend | indent 14 }}
+{{- end }}
 
+  tls:
+    - hosts:
+        - "{{ .Values.wildcardhostname }}"
+      secretName: "{{ .Values.tls }}"
+{{- end }}
 ---
 apiVersion: {{ .Values.service.apiversion }}
 kind: Service
@@ -111,6 +137,10 @@ spec:
       port: 80
       protocol: TCP
       targetPort: 5000
+    - name: port
+      port: 82
+      protocol: TCP
+      targetPort: 8080
   selector:
     app: ph-ee-connector-channel
   sessionAffinity: None

--- a/helm/ph-ee-engine/values.yaml
+++ b/helm/ph-ee-engine/values.yaml
@@ -193,6 +193,7 @@ channel:
   TRANSACTION_ID_LENGTH: 20
   DFSPIDS: ""
   hostname: ""
+  stub_hostname: ""
   limits:
     memory: "768M"
     cpu: "500m"
@@ -204,6 +205,7 @@ channel:
     path: "/channel"
     annotations: {}
     backend: {}
+    stub_backend: {}
   deployment:
     annotations: {}
 


### PR DESCRIPTION
Updates in this pr
1. `ph-ee-connector-channel` service now opens new 82:8080 to allow access to stub APIs at tomcat server port 8080.
2. Added new ingress `ph-ee-connector-channel-gsma` which will be used to access gsma stub APIs in channel connector.